### PR TITLE
2번째 트랜잭션 전파부터 listener 객체에 접근하지 못하는 문제

### DIFF
--- a/PracticeBlockChain.Cryptography/PublicKey.cs
+++ b/PracticeBlockChain.Cryptography/PublicKey.cs
@@ -1,10 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Signers;
 
 namespace PracticeBlockChain.Cryptography
 {
+    [Serializable]
     public class PublicKey
     {
         public PublicKey(byte[] publicKey)

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -199,6 +199,7 @@ namespace PracticeBlockChain.Network
             }
             else
             {
+                SendData(dataToSend);
                 _routingTable = (Dictionary<string, string>)GetData();
             }
             DisconnectToNode();

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -35,7 +35,11 @@ namespace PracticeBlockChain.Network
                         "127.0.0.1:" + (port + 1).ToString(), "127.0.0.1:" + port.ToString()
                     };
                 // It's peer node.
-                StartConnection(seedNodeAddress);
+                StartConnection
+                (
+                    destinationAddress: seedNodeAddress,
+                    dataToSend: string.Format(_address[0] + "," + _address[1])
+                );
             }
         }
 
@@ -170,7 +174,11 @@ namespace PracticeBlockChain.Network
                 {
                     continue;
                 }
-                StartConnection(address.Key);
+                StartConnection
+                (
+                    destinationAddress: address.Key,
+                    dataToSend: string.Format(_address[0] + "," + _address[1])
+                );
             }
         }
 
@@ -188,7 +196,7 @@ namespace PracticeBlockChain.Network
             Console.WriteLine();
         }
 
-        public void StartConnection(string destinationAddress)
+        public void StartConnection(string destinationAddress, object dataToSend)
         {
             string[] clientAddress = _address[0].Split(":");
 

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -13,22 +13,20 @@ namespace PracticeBlockChain.Network
 {
     public class Node
     {
-        // _routingTable = 
-        // {
-        //     peer's address of listener, 
-        //     [ peer's address of client, is it connected with this node? ] 
-        // }
+        // _routingTable = { peer's address of listener, peer's address of client }
         private Dictionary<string, string> _routingTable;
         private TcpClient _client;
         private TcpListener _listener;
         private NetworkStream _stream;
         private string[] _address;
+        private List<byte[]> _stage;
 
         public Node(bool isSeed, int port)
         {
             string seedNodeAddress = "127.0.0.1:65000";
 
             SetListener("127.0.0.1", port);
+            _stage = new List<byte[]>();
             _address =
                 new string[]
                 {
@@ -42,6 +40,9 @@ namespace PracticeBlockChain.Network
                     destinationAddress: seedNodeAddress,
                     dataToSend: string.Format(_address[0] + "," + _address[1])
                 );
+                _routingTable = (Dictionary<string, string>)GetData().Result;
+                PrintRoutingTable();
+                DisconnectToNode();
             }
         }
 
@@ -53,6 +54,11 @@ namespace PracticeBlockChain.Network
             }
         }
 
+        public Dictionary<string, string> RoutingTable
+        {
+            get
+            {
+                return _routingTable;
             }
         }
 
@@ -135,12 +141,9 @@ namespace PracticeBlockChain.Network
             _client.Dispose();
         }
 
-        private void PutAddressToRoutingtable(object client)
+        private void PutAddressToRoutingtable(string address)
         {
-            var node = (TcpClient)client;
-
-            string nodeAddress = (string)GetData();
-            string[] seperatedAddress = nodeAddress.Split(",");
+            string[] seperatedAddress = address.Split(",");
             Console.WriteLine($"Connected client: {seperatedAddress[0]}");
             if (!(_routingTable.ContainsKey(seperatedAddress[1])))
             {
@@ -200,11 +203,7 @@ namespace PracticeBlockChain.Network
             Console.WriteLine("\n<Routing table>");
             foreach (var address in _routingTable)
             {
-                Console.WriteLine
-                (
-                    $"Client: {address.Value}, " +
-                    $"Listener: {address.Key}"
-                );
+                Console.WriteLine($"Client: {address.Value}, Listener: {address.Key}");
             }
             Console.WriteLine();
         }

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -122,6 +122,7 @@ namespace PracticeBlockChain.Network
         {
             var node = (TcpClient)client;
 
+            string nodeAddress = (string)GetData();
             string[] seperatedAddress = nodeAddress.Split(",");
             Console.WriteLine($"Connected client: {seperatedAddress[0]}");
             if (!(_routingTable.ContainsKey(seperatedAddress[1])))
@@ -157,15 +158,8 @@ namespace PracticeBlockChain.Network
             var memoryStream = new MemoryStream(dataAsByte);
             memoryStream.Position = 0;
             var data = binaryFormatter.Deserialize(memoryStream);
-            if (data.GetType().FullName.Contains("System.Collections.Generic.Dictionary"))
-            {
-                _routingTable = (Dictionary<string, string>)data;
-                PrintRoutingTable();
-            }
-            else
-            {
-                Console.WriteLine($"Received from neighbornode: {data}");
-            }
+
+            return data;
         }
 
         public void RotateRoutingTable()
@@ -205,7 +199,7 @@ namespace PracticeBlockChain.Network
             }
             else
             {
-                GetData();
+                _routingTable = (Dictionary<string, string>)GetData();
             }
             DisconnectToNode();
         }

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -1,11 +1,13 @@
+using PracticeBlockChain.Cryptography;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace PracticeBlockChain.Network
 {
@@ -27,19 +29,30 @@ namespace PracticeBlockChain.Network
             string seedNodeAddress = "127.0.0.1:65000";
 
             SetListener("127.0.0.1", port);
+            _address =
+                new string[]
+                {
+                        "127.0.0.1:" + (port + 1).ToString(), "127.0.0.1:" + port.ToString()
+                };
             if (!isSeed)
             {
-                _address =
-                    new string[]
-                    {
-                        "127.0.0.1:" + (port + 1).ToString(), "127.0.0.1:" + port.ToString()
-                    };
                 // It's peer node.
                 StartConnection
                 (
                     destinationAddress: seedNodeAddress,
                     dataToSend: string.Format(_address[0] + "," + _address[1])
                 );
+            }
+        }
+
+        public string[] Address
+        {
+            get
+            {
+                return _address;
+            }
+        }
+
             }
         }
 

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -118,13 +118,6 @@ namespace PracticeBlockChain.Network
             _client.Dispose();
         }
 
-        private void SendAddress()
-        {
-            var byteAddress =
-                Encoding.ASCII.GetBytes(string.Format(_address[0] + "," + _address[1]));
-            _stream.Write(byteAddress, 0, byteAddress.Length);
-        }
-
         private string GetAddress(TcpClient node)
         {
             var bytes = new Byte[256];
@@ -224,7 +217,6 @@ namespace PracticeBlockChain.Network
             }
             else
             {
-                SendAddress();
                 GetData();
             }
             DisconnectToNode();

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -222,6 +222,7 @@ namespace PracticeBlockChain.Network
             return data;
         }
 
+        // Transport transaction to all of nodes from routing table.
         public async void RotateRoutingTable(object data)
         {
             string[] clientAddress = _address[0].Split(":");

--- a/PracticeBlockChain.Network/Node.cs
+++ b/PracticeBlockChain.Network/Node.cs
@@ -118,22 +118,10 @@ namespace PracticeBlockChain.Network
             _client.Dispose();
         }
 
-        private string GetAddress(TcpClient node)
-        {
-            var bytes = new Byte[256];
-            string nodeAddress = null;
-
-            int addressLength = _stream.Read(bytes, 0, bytes.Length);
-            nodeAddress = Encoding.ASCII.GetString(bytes, 0, addressLength);
-
-            return nodeAddress;
-        }
-
         private void PutAddressToRoutingtable(object client)
         {
             var node = (TcpClient)client;
 
-            string nodeAddress = GetAddress(node);
             string[] seperatedAddress = nodeAddress.Split(",");
             Console.WriteLine($"Connected client: {seperatedAddress[0]}");
             if (!(_routingTable.ContainsKey(seperatedAddress[1])))

--- a/PracticeBlockChain.Network/PracticeBlockChain.Network.csproj
+++ b/PracticeBlockChain.Network/PracticeBlockChain.Network.csproj
@@ -41,4 +41,8 @@
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\PracticeBlockChain.Cryptography\PracticeBlockChain.Cryptography.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/PracticeBlockChain.Test/NetworkTest.cs
+++ b/PracticeBlockChain.Test/NetworkTest.cs
@@ -45,6 +45,17 @@ namespace PracticeBlockChain.Test
             actionTask.Wait();
             _mutex.ReleaseMutex();
         }
+
+        private static void TransportAction
+        (
+            PrivateKey privateKey, BlockChain blockChain, Node node
+        )
+        {
+            var action = MakeAction(privateKey, blockChain);
+            node.RotateRoutingTable
+            (
+                new ArrayList { privateKey.PublicKey.Format(true), action.Signature, action.ActionId }
+            );
         }
 
         private static Action MakeAction(PrivateKey privateKey, BlockChain blockChain)

--- a/PracticeBlockChain.Test/NetworkTest.cs
+++ b/PracticeBlockChain.Test/NetworkTest.cs
@@ -13,5 +13,47 @@ namespace PracticeBlockChain.Test
                 node.RotateRoutingTable();
             }
         }
+
+        private static void SendAction
+        (
+            object lockThis, PrivateKey privateKey, BlockChain blockChain, Node node
+        )
+        {
+            lock (lockThis)
+            {
+                var action = MakeAction(privateKey, blockChain);
+                node.RotateRoutingTable
+                (
+                    new ArrayList { privateKey.PublicKey.Format(true), action.Signature, action.ActionId }
+                );
+            }
+        }
+
+        private static Action MakeAction(PrivateKey privateKey, BlockChain blockChain)
+        {
+            var address = new Address(privateKey.PublicKey);
+            byte[] signature =
+                privateKey.Sign
+                (
+                    new Action
+                    (
+                        txNonce: blockChain.GetHowmanyBlocksMinermade(address) + 1,
+                        signer: address,
+                        payload: null,
+                        signature: null
+                    ).Hash()
+                );
+            var action =
+                new Action
+                (
+                    txNonce:
+                    blockChain.GetHowmanyBlocksMinermade(address) + 1,
+                    signer: address,
+                    payload: null,
+                    signature: signature
+                );
+
+            return action;
+        }
     }
 }

--- a/PracticeBlockChain.Test/NetworkTest.cs
+++ b/PracticeBlockChain.Test/NetworkTest.cs
@@ -4,15 +4,26 @@ namespace PracticeBlockChain.Test
 {
     public class NetworkTest
     {
-        public static void Main(string[] args)
         private static object lockThis = new object();
 
+        public static async Task Main(string[] args)
         {
+            var blockChain = new BlockChain();
+            var privateKey = new PrivateKey();
             var node = new Node(isSeed: bool.Parse(args[0]), port: int.Parse(args[1]));
+
             if (!bool.Parse(args[0]))
             {
                 // It's peer node.
                 node.RotateRoutingTable();
+                while (true)
+                {
+                    var sendingActionThread =
+                        new Thread(() => SendAction(lockThis, privateKey, blockChain, node));
+                    sendingActionThread.Priority = ThreadPriority.Lowest;
+                    sendingActionThread.Start();
+                    await Task.Delay(10000);
+                }
             }
         }
 

--- a/PracticeBlockChain.Test/NetworkTest.cs
+++ b/PracticeBlockChain.Test/NetworkTest.cs
@@ -5,6 +5,8 @@ namespace PracticeBlockChain.Test
     public class NetworkTest
     {
         public static void Main(string[] args)
+        private static object lockThis = new object();
+
         {
             var node = new Node(isSeed: bool.Parse(args[0]), port: int.Parse(args[1]));
             if (!bool.Parse(args[0]))

--- a/PracticeBlockChain.Test/NetworkTest.cs
+++ b/PracticeBlockChain.Test/NetworkTest.cs
@@ -1,4 +1,9 @@
-﻿using PracticeBlockChain.Network;
+﻿using PracticeBlockChain.Cryptography;
+using PracticeBlockChain.Network;
+using System;
+using System.Collections;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PracticeBlockChain.Test
 {
@@ -15,7 +20,12 @@ namespace PracticeBlockChain.Test
             if (!bool.Parse(args[0]))
             {
                 // It's peer node.
-                node.RotateRoutingTable();
+                node.RotateRoutingTable
+                (
+                    string.Format(node.Address[0] + "," + node.Address[1])
+                );
+                while (node.RoutingTable.Count < 2) ;
+                
                 while (true)
                 {
                     var sendingActionThread =


### PR DESCRIPTION
(아래 2개가 주된 커밋입니다)
[Extract function](https://github.com/yoonmyung/BlockChain/commit/4f62338eeaf2dc45e50668d28b522aef37ee5b74)
[트랜잭션 전파에 사용하는 함수 표기용 커밋](https://github.com/yoonmyung/BlockChain/commit/d9cb172770e82e0e0bd85a1819d3c69a98b398b5)

(결과)
![image](https://user-images.githubusercontent.com/40621689/115369459-153f3e80-a203-11eb-9d1b-8c941fc76fce.png)
왼쪽이 먼저 생긴 노드(listener 포트 65002), 오른쪽이 나중에 생긴 노드(listener 포트 65004)입니다
드래그 된 부분은 왼쪽 노드가 먼저 트랜잭션 전파를 하면, 오른쪽 노드가 받은 과정입니다.
아래 10048 에러들이 두번째 전파부터 계속 트랜잭션을 보내는 노드 쪽에서 전파 받는 노드의 listener 포트가 이미 사용 중이라고 뜨고 있는 상황입니다.

Node.cs의 Listen() 함수에서는 client로부터 연결이 들어올 때마다 스레드로 처리하기 때문에 다중 연결이 가능한데
listener 객체를 없앴다가 매번 연결할 때 새로 생성해야 해결되는 문제인지..
(같은 함수를 쓰고 있는 시드 노드에서는 매번 새로 들어오는 연결을 잘 받고 있는 상황)